### PR TITLE
Feature/support multi column unique index

### DIFF
--- a/inspection.go
+++ b/inspection.go
@@ -216,8 +216,8 @@ ORDER BY a.attnum`
 		switch c.Constraint.String {
 		case "p":
 			c.PrimaryKey = true
-		case "u":
-			c.Unique = true
+		//case "u":
+		//	c.Unique = true
 		}
 		if c.SerialSrc.Valid {
 			c.Serial = true

--- a/inspection.go
+++ b/inspection.go
@@ -54,6 +54,7 @@ type Type struct {
 type Index struct {
 	DataType string
 	Name     string
+	Columns  []Column
 	Comment  sql.NullString
 }
 

--- a/templates/hibernate/class.tmpl
+++ b/templates/hibernate/class.tmpl
@@ -30,6 +30,17 @@ import com.google.gson.JsonObject;
 @Entity
 @Table(name="{{ .table.Name }}"
     ,schema="public"
+{{ if .table.Indexs}}
+    ,uniqueConstraints = {
+  {{- range .table.Indexs }}
+      @UniqueConstraint(columnNames = {
+    {{- range .Columns }}
+      "{{ .Name }}",
+    {{ end }}
+      }),
+  {{ end }}
+    }
+{{ end }}
 )
 @SuppressWarnings("serial")
 public class {{ .name }} implements java.io.Serializable {


### PR DESCRIPTION
### overview
- support unique index using multiple column.
- It integrate single column unique index to class annotation.

### query schema def
```
SELECT c2.relname, 
       i.indisprimary, 
       i.indisunique, 
       i.indisclustered, 
       i.indisvalid, 
       pg_catalog.Pg_get_indexdef(i.indexrelid, 0, true), 
       pg_catalog.Pg_get_constraintdef(con.oid, true), 
       contype, 
       condeferrable, 
       condeferred, 
       i.indisreplident, 
       c2.reltablespace 
FROM   pg_catalog.pg_class c, 
       pg_catalog.pg_class c2, 
       pg_catalog.pg_index i 
       LEFT JOIN pg_catalog.pg_constraint con 
              ON ( conrelid = i.indrelid 
                   AND conindid = i.indexrelid 
                   AND contype IN ( 'p', 'u', 'x' ) ) 
WHERE  c.relname = 'hoge' 
       AND c.oid = i.indrelid 
       AND i.indexrelid = c2.oid 
ORDER  BY i.indisprimary DESC, 
          i.indisunique DESC, 
          c2.relname; 
```



### Output sample

```
@Entity
@Table(
    name = "table_name",
    schema = "public",
    uniqueConstraints = {
      @UniqueConstraint(
          columnNames = {
            "column1_name",
            "column2_name",
          }),
      @UniqueConstraint(
          columnNames = {
            "column3_name",
          }),
      @UniqueConstraint(
          columnNames = {
            "column4_name",
          }),
    })
@SuppressWarnings("serial")
```